### PR TITLE
Fix login redirect path

### DIFF
--- a/docs/api/onboarding.md
+++ b/docs/api/onboarding.md
@@ -4,7 +4,7 @@
 - **URL:** `/login/`
 - **Method:** `POST`
 - **Payload:** `username`, `password`
-- **Response:** Redirects to dashboard on success
+- **Response:** Redirects to `/` (dashboard) on success
 
 ## Add Company
 - **URL:** `/companies/add/`

--- a/erp_project/accounts/tests.py
+++ b/erp_project/accounts/tests.py
@@ -38,6 +38,14 @@ class OnboardingTests(TestCase):
         user.refresh_from_db()
         self.assertFalse(user.is_active)
 
+    def test_login_redirects_to_dashboard(self):
+        response = self.client.post(
+            reverse('login'),
+            {'username': 'admin', 'password': 'pass'}
+        )
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response['Location'], '/')
+
 class PermissionTests(TestCase):
     def setUp(self):
         self.superuser = User.objects.create_superuser(username='admin', password='pass')

--- a/erp_project/erp_project/settings.py
+++ b/erp_project/erp_project/settings.py
@@ -122,3 +122,8 @@ STATIC_URL = 'static/'
 
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 AUTH_USER_MODEL = 'accounts.User'
+
+# Redirect users to the dashboard after login to avoid the default
+# `/accounts/profile/` path which does not exist in this project.
+LOGIN_REDIRECT_URL = '/'
+LOGOUT_REDIRECT_URL = '/login/'

--- a/erp_project/templates/company_form.html
+++ b/erp_project/templates/company_form.html
@@ -2,9 +2,29 @@
 {% block title %}Add Company{% endblock %}
 {% block content %}
 <h2>Add Company</h2>
-<form method="post">
+<form method="post" class="needs-validation" novalidate>
   {% csrf_token %}
-  {{ form.as_p }}
+  <div class="mb-3">
+    <label for="id_name" class="form-label">Name</label>
+    <input type="text" name="name" id="id_name" class="form-control" value="{{ form.name.value|default:'' }}" required>
+    {% for error in form.name.errors %}
+      <div class="invalid-feedback">{{ error }}</div>
+    {% endfor %}
+  </div>
+  <div class="mb-3">
+    <label for="id_code" class="form-label">Code</label>
+    <input type="text" name="code" id="id_code" class="form-control" value="{{ form.code.value|default:'' }}" required>
+    {% for error in form.code.errors %}
+      <div class="invalid-feedback">{{ error }}</div>
+    {% endfor %}
+  </div>
+  <div class="mb-3">
+    <label for="id_address" class="form-label">Address</label>
+    <input type="text" name="address" id="id_address" class="form-control" value="{{ form.address.value|default:'' }}">
+    {% for error in form.address.errors %}
+      <div class="invalid-feedback">{{ error }}</div>
+    {% endfor %}
+  </div>
   <button type="submit" class="btn btn-success">Save</button>
 </form>
 {% endblock %}

--- a/erp_project/templates/login.html
+++ b/erp_project/templates/login.html
@@ -4,9 +4,22 @@
 <div class="row justify-content-center">
   <div class="col-md-4">
     <h2>Login</h2>
-    <form method="post">
+    <form method="post" class="needs-validation" novalidate>
       {% csrf_token %}
-      {{ form.as_p }}
+      <div class="mb-3">
+        <label for="id_username" class="form-label">Username</label>
+        <input type="text" name="username" id="id_username" class="form-control" required>
+        {% for error in form.username.errors %}
+          <div class="invalid-feedback">{{ error }}</div>
+        {% endfor %}
+      </div>
+      <div class="mb-3">
+        <label for="id_password" class="form-label">Password</label>
+        <input type="password" name="password" id="id_password" class="form-control" required>
+        {% for error in form.password.errors %}
+          <div class="invalid-feedback">{{ error }}</div>
+        {% endfor %}
+      </div>
       <button type="submit" class="btn btn-primary">Login</button>
     </form>
   </div>

--- a/erp_project/templates/user_form.html
+++ b/erp_project/templates/user_form.html
@@ -2,9 +2,52 @@
 {% block title %}User Form{% endblock %}
 {% block content %}
 <h2>User Form</h2>
-<form method="post">
+<form method="post" class="needs-validation" novalidate>
   {% csrf_token %}
-  {{ form.as_p }}
+  <div class="mb-3">
+    <label for="id_username" class="form-label">Username</label>
+    <input type="text" name="username" id="id_username" class="form-control" value="{{ form.username.value|default:'' }}" required>
+    {% for error in form.username.errors %}
+      <div class="invalid-feedback">{{ error }}</div>
+    {% endfor %}
+  </div>
+  <div class="mb-3">
+    <label for="id_email" class="form-label">Email</label>
+    <input type="email" name="email" id="id_email" class="form-control" value="{{ form.email.value|default:'' }}">
+    {% for error in form.email.errors %}
+      <div class="invalid-feedback">{{ error }}</div>
+    {% endfor %}
+  </div>
+  <div class="mb-3">
+    <label for="id_first_name" class="form-label">First name</label>
+    <input type="text" name="first_name" id="id_first_name" class="form-control" value="{{ form.first_name.value|default:'' }}">
+    {% for error in form.first_name.errors %}
+      <div class="invalid-feedback">{{ error }}</div>
+    {% endfor %}
+  </div>
+  <div class="mb-3">
+    <label for="id_last_name" class="form-label">Last name</label>
+    <input type="text" name="last_name" id="id_last_name" class="form-control" value="{{ form.last_name.value|default:'' }}">
+    {% for error in form.last_name.errors %}
+      <div class="invalid-feedback">{{ error }}</div>
+    {% endfor %}
+  </div>
+  {% if form.password1 %}
+  <div class="mb-3">
+    <label for="id_password1" class="form-label">Password</label>
+    <input type="password" name="password1" id="id_password1" class="form-control" required>
+    {% for error in form.password1.errors %}
+      <div class="invalid-feedback">{{ error }}</div>
+    {% endfor %}
+  </div>
+  <div class="mb-3">
+    <label for="id_password2" class="form-label">Confirm Password</label>
+    <input type="password" name="password2" id="id_password2" class="form-control" required>
+    {% for error in form.password2.errors %}
+      <div class="invalid-feedback">{{ error }}</div>
+    {% endfor %}
+  </div>
+  {% endif %}
   <button type="submit" class="btn btn-success">Save</button>
 </form>
 {% endblock %}


### PR DESCRIPTION
## Summary
- redirect logins to the dashboard so `/accounts/profile/` 404s don't appear
- document login redirect in onboarding docs
- test login redirect behaviour
- rewrite form templates with custom HTML as per Agents.md guidelines

## Testing
- `python manage.py test -v 2` *(inside erp_project)*
- `python manage.py test accounts.tests.OnboardingTests.test_login_redirects_to_dashboard -v 2`


------
https://chatgpt.com/codex/tasks/task_e_6853e8d4c9f48324ae6f8755226d7452