### PR TITLE
Fix logout 405 and add test

### DIFF
--- a/erp_project/accounts/tests.py
+++ b/erp_project/accounts/tests.py
@@ -46,6 +46,16 @@ class OnboardingTests(TestCase):
         self.assertEqual(response.status_code, 302)
         self.assertEqual(response['Location'], '/')
 
+    def test_superuser_can_logout_via_button(self):
+        self.client.login(username='admin', password='pass')
+        dashboard = self.client.get(reverse('dashboard'))
+        self.assertContains(dashboard, reverse('logout'))
+        logout_response = self.client.get(reverse('logout'))
+        self.assertEqual(logout_response.status_code, 302)
+        self.assertEqual(logout_response['Location'], reverse('login'))
+        follow_up = self.client.get(reverse('dashboard'))
+        self.assertEqual(follow_up.status_code, 302)
+
 class PermissionTests(TestCase):
     def setUp(self):
         self.superuser = User.objects.create_superuser(username='admin', password='pass')

--- a/erp_project/accounts/views.py
+++ b/erp_project/accounts/views.py
@@ -30,7 +30,8 @@ class CustomLoginView(LoginView):
 from django.views.generic import DetailView, UpdateView, ListView, View
 from django.shortcuts import get_object_or_404, redirect
 from django.http import JsonResponse
-from django.contrib.auth import get_user_model
+from django.contrib.auth import get_user_model, logout
+from django.conf import settings
 from .forms import CompanyUserCreationForm
 from .models import Role, UserRole
 
@@ -124,4 +125,12 @@ def permission_denied_view(request, exception):
         return JsonResponse({'detail': 'Permission denied'}, status=403)
     template = loader.get_template('403.html')
     return HttpResponseForbidden(template.render({}, request))
+
+
+class CustomLogoutView(View):
+    """Allow GET logout to support navigation link."""
+
+    def get(self, request):
+        logout(request)
+        return redirect(settings.LOGOUT_REDIRECT_URL)
 

--- a/erp_project/erp_project/urls.py
+++ b/erp_project/erp_project/urls.py
@@ -16,7 +16,7 @@ Including another URLconf
 """
 from django.contrib import admin
 from django.urls import path
-from django.contrib.auth.views import LogoutView
+from accounts.views import CustomLogoutView
 from accounts.views import (
     CustomLoginView, DashboardView, CompanyCreateView, CompanyListView,
     CompanyDetailView, CompanyUpdateView, UserListView, CompanyUserCreateView,
@@ -26,7 +26,7 @@ from accounts.views import (
 urlpatterns = [
     path('admin/', admin.site.urls),
     path('login/', CustomLoginView.as_view(), name='login'),
-    path('logout/', LogoutView.as_view(), name='logout'),
+    path('logout/', CustomLogoutView.as_view(), name='logout'),
     path('companies/', CompanyListView.as_view(), name='company_list'),
     path('companies/add/', CompanyCreateView.as_view(), name='company_add'),
     path('companies/<int:pk>/', CompanyDetailView.as_view(), name='company_detail'),

--- a/workflow.md
+++ b/workflow.md
@@ -124,3 +124,4 @@ Here’s your **expanded checklist** including **CRUD views, session/auth, and a
 * This covers all **CRUD**, **specialized**, and **auth/session** views for the onboarding workflow.
 
 Navigation updated to include Users link for company admins.
+Logout view updated to accept GET requests so the navbar logout button works.


### PR DESCRIPTION
## Summary
- implement `CustomLogoutView` that handles GET
- wire logout URL to new view
- test logout link works for superuser
- document logout behaviour change

## Testing
- `python erp_project/manage.py test accounts`

------
https://chatgpt.com/codex/tasks/task_e_68543ab29f9883248f839c6978a24c11