### PR TITLE
Enable Argon2 password hashing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
 # ERPSoftwareFinal
+
+This project is a sample ERP system implemented with Django. It demonstrates multi-tenant onboarding, role based permissions, and custom HTMX forms for interaction.
+
+## Password Hashing
+
+Passwords are stored using the Argon2 hashing algorithm for improved security. Ensure `argon2-cffi` is installed when deploying.

--- a/erp_project/accounts/tests.py
+++ b/erp_project/accounts/tests.py
@@ -149,7 +149,7 @@ class CompanyUserLoginTests(TestCase):
         if resp.status_code != 302:
             self.fail(f"Form errors: {resp.context['form'].errors}")
         user = User.objects.get(username='coadmin')
-        self.assertTrue(user.password.startswith('pbkdf2_'))
+        self.assertTrue(user.password.startswith('argon2$'))
 
     def test_company_user_navbar_and_user_list_access(self):
         user = User.objects.create_user(username='emp', password='emp123', company=self.company)

--- a/erp_project/erp_project/settings.py
+++ b/erp_project/erp_project/settings.py
@@ -99,6 +99,15 @@ AUTH_PASSWORD_VALIDATORS = [
     },
 ]
 
+# Use Argon2 as the default hasher with fallbacks for existing hashes
+PASSWORD_HASHERS = [
+    'django.contrib.auth.hashers.Argon2PasswordHasher',
+    'django.contrib.auth.hashers.PBKDF2PasswordHasher',
+    'django.contrib.auth.hashers.PBKDF2SHA1PasswordHasher',
+    'django.contrib.auth.hashers.BCryptSHA256PasswordHasher',
+    'django.contrib.auth.hashers.ScryptPasswordHasher',
+]
+
 
 # Internationalization
 # https://docs.djangoproject.com/en/5.2/topics/i18n/

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ asgiref==3.8.1
 Django==5.2.3
 sqlparse==0.5.3
 tzdata==2025.2
+argon2-cffi==23.1.0


### PR DESCRIPTION
## Summary
- add `argon2-cffi` to dependencies
- use Argon2 as default hasher with fallbacks
- update password hashing test to expect Argon2
- clarify README about hashing

## Testing
- `pip install -r requirements.txt`
- `python erp_project/manage.py test accounts`

------
https://chatgpt.com/codex/tasks/task_e_685441f4ff548324b41bdfc33c1ecdbe