### PR TITLE
Fix permission checks in user detail view

### DIFF
--- a/erp_project/accounts/tests.py
+++ b/erp_project/accounts/tests.py
@@ -326,4 +326,12 @@ class ButtonVisibilityTests(TestCase):
         self.assertNotContains(resp, reverse('user_edit', args=[self.user.id]))
         self.assertContains(resp, reverse('user_change_password', args=[self.user.id]))
 
+    def test_admin_sees_management_buttons(self):
+        """Admin user should see edit, password, and toggle controls."""
+        self.client.login(username='admin2', password='pass')
+        resp = self.client.get(reverse('user_detail', args=[self.user.id]))
+        self.assertContains(resp, reverse('user_edit', args=[self.user.id]))
+        self.assertContains(resp, reverse('user_change_password', args=[self.user.id]))
+        self.assertContains(resp, reverse('user_toggle', args=[self.user.id]))
+
 

--- a/erp_project/accounts/views.py
+++ b/erp_project/accounts/views.py
@@ -4,7 +4,7 @@ from django.urls import reverse_lazy
 from django.views.generic import CreateView, TemplateView
 from .models import Company
 from django.utils.decorators import method_decorator
-from .utils import require_permission, log_action
+from .utils import require_permission, log_action, user_has_permission
 
 class SuperuserRequiredMixin(UserPassesTestMixin):
     def test_func(self):
@@ -126,8 +126,27 @@ class CompanyUserCreateView(View):
 
 @method_decorator(require_permission('view_user'), name='dispatch')
 class UserDetailView(LoginRequiredMixin, AdminRequiredMixin, DetailView):
+    """Display details for a user with permission aware actions."""
+
     model = User
     template_name = 'user_detail.html'
+    # Avoid clashing with the request "user" context variable
+    context_object_name = 'target'
+
+    def get_context_data(self, **kwargs):
+        """Inject permission flags for template button visibility."""
+        context = super().get_context_data(**kwargs)
+        target = context['target']
+        req_user = self.request.user
+        context['can_edit'] = user_has_permission(req_user, 'change_user')
+        context['can_change_password'] = (
+            user_has_permission(req_user, 'user_can_change_password')
+            or req_user.pk == target.pk
+        )
+        context['can_toggle'] = (
+            user_has_permission(req_user, 'change_user') and req_user.pk != target.pk
+        )
+        return context
 
 @method_decorator(require_permission('change_user'), name='dispatch')
 class UserUpdateView(LoginRequiredMixin, AdminRequiredMixin, UpdateView):

--- a/erp_project/templates/user_detail.html
+++ b/erp_project/templates/user_detail.html
@@ -1,21 +1,20 @@
 {% extends 'base.html' %}
-{% load permissions_tags %}
 {% block title %}User Detail{% endblock %}
 {% block content %}
-<h2>{{ object.username }}</h2>
-<p>Email: {{ object.email }}</p>
-<p>Name: {{ object.first_name }} {{ object.last_name }}</p>
-<p>Status: {{ object.is_active|yesno:"Active,Inactive" }}</p>
-{% if user|has_permission:'change_user' %}
-<a href="{% url 'user_edit' object.id %}" class="btn btn-primary">Edit</a>
+<h2>{{ target.username }}</h2>
+<p>Email: {{ target.email }}</p>
+<p>Name: {{ target.first_name }} {{ target.last_name }}</p>
+<p>Status: {{ target.is_active|yesno:"Active,Inactive" }}</p>
+{% if can_edit %}
+<a href="{% url 'user_edit' target.id %}" class="btn btn-primary">Edit</a>
 {% endif %}
-{% if user|has_permission:'user_can_change_password' or user.id == object.id %}
-<a href="{% url 'user_change_password' object.id %}" class="btn btn-secondary">Change Password</a>
+{% if can_change_password %}
+<a href="{% url 'user_change_password' target.id %}" class="btn btn-secondary">Change Password</a>
 {% endif %}
-{% if user|has_permission:'change_user' and user.id != object.id %}
-<form method="post" action="{% url 'user_toggle' object.id %}" class="d-inline">
+{% if can_toggle %}
+<form method="post" action="{% url 'user_toggle' target.id %}" class="d-inline">
   {% csrf_token %}
-  <button type="submit" class="btn btn-warning">{% if object.is_active %}Deactivate{% else %}Reactivate{% endif %}</button>
+  <button type="submit" class="btn btn-warning">{% if target.is_active %}Deactivate{% else %}Reactivate{% endif %}</button>
 </form>
 {% endif %}
 {% endblock %}


### PR DESCRIPTION
## Summary
- use separate `target` context object in `UserDetailView`
- add view-level permission flags for editing/toggling/changing passwords
- update `user_detail.html` to rely on new flags
- test that admins can see management buttons

## Testing
- `python erp_project/manage.py test accounts --verbosity 2`

------
https://chatgpt.com/codex/tasks/task_e_68545f3018a4832494746dd3a478881b