### PR TITLE
Implement audit log detail view

### DIFF
--- a/docs/api/auditlog.md
+++ b/docs/api/auditlog.md
@@ -6,3 +6,10 @@
 - **Auth:** Logged in users with `view_auditlog` permission or superuser.
 - **Description:** Shows latest 100 audit log entries. Non-superusers only see logs from their company.
 - **Response:** HTML table with timestamp, user, action, request type, target user, and company.
+
+## Log Detail
+- **URL:** `/audit-logs/<id>/`
+- **Method:** `GET`
+- **Auth:** Logged in users with `view_auditlog` permission or superuser.
+- **Description:** Shows a single audit log entry with fields and formatted JSON details.
+- **Response:** HTML page with log info and pretty-printed details.

--- a/erp_project/erp_project/urls.py
+++ b/erp_project/erp_project/urls.py
@@ -22,7 +22,7 @@ from accounts.views import (
     CompanyDetailView, CompanyUpdateView, UserListView, CompanyUserCreateView,
     UserDetailView, UserUpdateView, UserToggleActiveView, WhoAmIView, DashboardAPI,
     RoleListView, RoleCreateView, RoleUpdateView, change_password_view,
-    AuditLogListView,
+    AuditLogListView, AuditLogDetailView,
 )
 
 urlpatterns = [
@@ -43,6 +43,7 @@ urlpatterns = [
     path('roles/add/', RoleCreateView.as_view(), name='role_add'),
     path('roles/<int:pk>/edit/', RoleUpdateView.as_view(), name='role_edit'),
     path('audit-logs/', AuditLogListView.as_view(), name='audit_log_list'),
+    path('audit-logs/<int:pk>/', AuditLogDetailView.as_view(), name='audit_log_detail'),
     path('api/whoami/', WhoAmIView.as_view(), name='whoami'),
     path('api/dashboard/', DashboardAPI.as_view(), name='dashboard_api'),
     path('', DashboardView.as_view(), name='dashboard'),

--- a/erp_project/templates/audit_log_detail.html
+++ b/erp_project/templates/audit_log_detail.html
@@ -1,0 +1,32 @@
+{% extends 'base.html' %}
+{% block title %}Audit Log Detail{% endblock %}
+{% block content %}
+<h2>Audit Log Entry</h2>
+<table class="table table-bordered">
+  <tbody>
+    <tr><th>Timestamp</th><td>{{ log.timestamp }}</td></tr>
+    <tr><th>User</th><td>{{ log.actor.username }}</td></tr>
+    <tr><th>Action</th><td>{{ log.action }}</td></tr>
+    <tr><th>Type</th><td>{{ log.request_type }}</td></tr>
+    <tr><th>Target</th><td>{{ log.target_user }}</td></tr>
+    <tr><th>Company</th><td>{{ log.company }}</td></tr>
+  </tbody>
+</table>
+{% if detail_rows %}
+<h4>Details</h4>
+<table class="table table-sm table-striped">
+  <tbody>
+  {% for key, value in detail_rows %}
+    <tr>
+      <th>{{ key }}</th>
+      <td><pre>{{ value }}</pre></td>
+    </tr>
+  {% endfor %}
+  </tbody>
+</table>
+{% elif log.details %}
+<h4>Details</h4>
+<pre>{{ log.details }}</pre>
+{% endif %}
+<a href="{% url 'audit_log_list' %}" class="btn btn-secondary">Back</a>
+{% endblock %}

--- a/erp_project/templates/audit_log_list.html
+++ b/erp_project/templates/audit_log_list.html
@@ -11,6 +11,7 @@
       <th>Type</th>
       <th>Target</th>
       <th>Company</th>
+      <th></th>
     </tr>
   </thead>
   <tbody>
@@ -22,6 +23,7 @@
       <td>{{ log.request_type }}</td>
       <td>{{ log.target_user }}</td>
       <td>{{ log.company }}</td>
+      <td><a href="{% url 'audit_log_detail' log.id %}">View</a></td>
     </tr>
     {% endfor %}
   </tbody>

--- a/workflow.md
+++ b/workflow.md
@@ -118,6 +118,7 @@ Here’s your **expanded checklist** including **CRUD views, session/auth, and a
 | 37 | **Audit Logging Middleware for all requests**                 | ✅ Implemented by Agent |
 | 38 | **Role Management (list/create/update) UI & API**             | ✅ Implemented by Agent |
 | 39 | **Audit Log list view with filtering**                        | ✅ Implemented by Agent |
+| 40 | **Audit Log detail view with formatted JSON**                 | ✅ Implemented by Agent |
 
 ---
 


### PR DESCRIPTION
## Summary
- add AuditLogDetailView with JSON parsing
- link to detail from the audit log list
- document API endpoint
- track workflow completion
- test detail access permissions

## Testing
- `python erp_project/manage.py test accounts`

------
https://chatgpt.com/codex/tasks/task_e_6854ec4b373483249fa7cb9c69608ae3