### PR TITLE
Improve list UX and profile layout

### DIFF
--- a/erp_project/templates/audit_log_list.html
+++ b/erp_project/templates/audit_log_list.html
@@ -3,6 +3,7 @@
 {% block content %}
 <h2>Audit Logs</h2>
 {% include 'includes/filter_form.html' %}
+<div id="list-container">
 <table class="table">
   <thead>
     <tr>
@@ -30,4 +31,5 @@
   </tbody>
 </table>
 {% include 'includes/pagination.html' %}
+</div>
 {% endblock %}

--- a/erp_project/templates/company_list.html
+++ b/erp_project/templates/company_list.html
@@ -3,6 +3,7 @@
 {% block content %}
 <h2>Companies</h2>
 {% include 'includes/filter_form.html' %}
+<div id="list-container">
 <table class="table">
   <thead>
     <tr>
@@ -18,4 +19,5 @@
   </tbody>
 </table>
 {% include 'includes/pagination.html' %}
+</div>
 {% endblock %}

--- a/erp_project/templates/includes/filter_form.html
+++ b/erp_project/templates/includes/filter_form.html
@@ -1,12 +1,16 @@
-<form method="get" class="row mb-3">
+<form method="get" class="row mb-3"
+      hx-get="." hx-target="#list-container" hx-push-url="true"
+      hx-trigger="keyup changed delay:500ms">
   {% if search %}
   <div class="col-auto">
-    <input type="text" name="q" value="{{ request.GET.q }}" class="form-control" placeholder="Search">
+    <label for="id_q" class="form-label visually-hidden">Search</label>
+    <input type="text" id="id_q" name="q" value="{{ request.GET.q }}" class="form-control" placeholder="Search">
   </div>
   {% endif %}
   {% for f in filters %}
   <div class="col-auto">
-    <select name="{{ f.name }}" class="form-select">
+    <label for="id_{{ f.name }}" class="form-label">{{ f.label }}</label>
+    <select name="{{ f.name }}" id="id_{{ f.name }}" class="form-select">
       {% for opt in f.options %}
       <option value="{{ opt.val }}" {% if f.current|stringformat:'s' == opt.val|stringformat:'s' %}selected{% endif %}>{{ opt.label }}</option>
       {% endfor %}

--- a/erp_project/templates/includes/sortable_th.html
+++ b/erp_project/templates/includes/sortable_th.html
@@ -1,10 +1,12 @@
 {% comment %}Reusable table header cell with sort links{% endcomment %}
 <th>
-  {{ label }}
-  {% if field %}
-  {% with asc=field desc='-'|add:field %}
-  <a href="?{{ sort_query_string }}{% if sort_query_string %}&{% endif %}sort={{ asc }}" class="ms-1{% if request.GET.sort == asc %} fw-bold{% endif %}">▲</a>
-  <a href="?{{ sort_query_string }}{% if sort_query_string %}&{% endif %}sort={{ desc }}" class="ms-1{% if request.GET.sort == desc %} fw-bold{% endif %}">▼</a>
+  {% with current=request.GET.sort %}
+    {% if current == field %}
+      <a href="?{{ sort_query_string }}{% if sort_query_string %}&{% endif %}sort=-{{ field }}">{{ label }}</a> ▲
+    {% elif current == '-'|add:field %}
+      <a href="?{{ sort_query_string }}{% if sort_query_string %}&{% endif %}sort={{ field }}">{{ label }}</a> ▼
+    {% else %}
+      <a href="?{{ sort_query_string }}{% if sort_query_string %}&{% endif %}sort={{ field }}">{{ label }}</a>
+    {% endif %}
   {% endwith %}
-  {% endif %}
 </th>

--- a/erp_project/templates/role_list.html
+++ b/erp_project/templates/role_list.html
@@ -7,6 +7,7 @@
 <a href="{% url 'role_add' %}" class="btn btn-success mb-2">Add Role</a>
 {% endif %}
 {% include 'includes/filter_form.html' %}
+<div id="list-container">
 <table class="table">
   <thead>
     <tr>
@@ -30,4 +31,5 @@
   </tbody>
 </table>
 {% include 'includes/pagination.html' %}
+</div>
 {% endblock %}

--- a/erp_project/templates/user_detail.html
+++ b/erp_project/templates/user_detail.html
@@ -1,39 +1,72 @@
 {% extends 'base.html' %}
 {% block title %}User Detail{% endblock %}
 {% block content %}
-<h2>{{ target.username }}</h2>
-{% if target.profile_picture %}
-<img src="{{ target.profile_picture.url }}" class="img-thumbnail mb-2" width="150">
-{% endif %}
-<p>Email: {{ target.email }}</p>
-<p>Name: {{ target.first_name }} {{ target.last_name }}</p>
-<p>Status: {{ target.is_active|yesno:"Active,Inactive" }}</p>
-{% if roles %}
-<h5>Roles</h5>
-<ul>
-  {% for r in roles %}<li>{{ r }}</li>{% endfor %}
-</ul>
-{% endif %}
+<h2 class="mb-4">{{ target.username }}</h2>
+<div class="row mb-4">
+  <div class="col-md-3 text-center">
+    {% if target.profile_picture %}
+    <img src="{{ target.profile_picture.url }}" class="img-thumbnail mb-2" width="150">
+    {% endif %}
+  </div>
+  <div class="col-md-9">
+    <div class="card mb-3">
+      <div class="card-body">
+        <p class="mb-1"><strong>Email:</strong> {{ target.email }}</p>
+        <p class="mb-1"><strong>Name:</strong> {{ target.first_name }} {{ target.last_name }}</p>
+        <p class="mb-1"><strong>Status:</strong> {{ target.is_active|yesno:"Active,Inactive" }}</p>
+        {% if roles %}
+        <p class="mb-0"><strong>Roles:</strong> {{ roles|join:', ' }}</p>
+        {% endif %}
+      </div>
+    </div>
+  </div>
+</div>
+
 {% if permissions %}
-<h5>Permissions</h5>
-<ul>
-  {% for p in permissions %}<li>{{ p }}</li>{% endfor %}
-</ul>
+<div class="card mb-4">
+  <div class="card-header">Permissions</div>
+  <div class="card-body">
+    <ul class="mb-0">
+      {% for p in permissions %}<li>{{ p }}</li>{% endfor %}
+    </ul>
+  </div>
+</div>
 {% endif %}
+
 {% if logs %}
-<h5>Recent Activity</h5>
-<ul class="list-group mb-2">
-  {% for log in logs %}
-  <li class="list-group-item">{{ log.timestamp }} - {{ log.action }}</li>
-  {% endfor %}
-</ul>
+<div class="card mb-4">
+  <div class="card-header d-flex justify-content-between align-items-center">
+    <span>Recent Activity</span>
+    <a href="{{ all_logs_url }}" class="btn btn-sm btn-outline-secondary">View all</a>
+  </div>
+  <div class="card-body p-0">
+    <table class="table mb-0">
+      <thead>
+        <tr>
+          <th>Timestamp</th>
+          <th>Action</th>
+          <th>Type</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for log in logs %}
+        <tr>
+          <td>{{ log.timestamp }}</td>
+          <td>{{ log.action }}</td>
+          <td>{{ log.request_type }}</td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+</div>
 {% endif %}
 {% if can_edit %}
 <a href="{% url 'user_edit' target.id %}" class="btn btn-primary">Edit</a>
 {% endif %}
-{% if can_change_password %}
-<a href="{% url 'user_change_password' target.id %}" class="btn btn-secondary">Change Password</a>
-{% endif %}
+  {% if can_change_password %}
+  <a href="{% url 'user_change_password' target.id %}" class="btn btn-secondary">Change Password</a>
+  {% endif %}
 {% if can_toggle %}
 <form method="post" action="{% url 'user_toggle' target.id %}" class="d-inline">
   {% csrf_token %}

--- a/erp_project/templates/user_list.html
+++ b/erp_project/templates/user_list.html
@@ -7,6 +7,7 @@
 <a href="{% url 'user_add' company.id %}" class="btn btn-success mb-2">Add User</a>
 {% endif %}
 {% include 'includes/filter_form.html' %}
+<div id="list-container">
 <table class="table">
   <thead>
     <tr>
@@ -28,4 +29,5 @@
   </tbody>
 </table>
 {% include 'includes/pagination.html' %}
+</div>
 {% endblock %}

--- a/workflow.md
+++ b/workflow.md
@@ -141,3 +141,4 @@ Implemented role management screens and ability to change a user's role during e
 Creating a new role from the user form now requires the `add_role` permission.
 User detail view now shows role, permissions, recent audit logs and profile pictures. User list supports search and pagination.
 List views now share filter and pagination components. All list tables allow sorting by any column via reusable headers.
+Filter forms now use HTMX for live updates with a 500ms delay and include labels for each field. Sorting arrows display only on the active column and the user profile view uses cards with a recent activity table.


### PR DESCRIPTION
## Summary
- add HTMX auto-update filtering with labels
- simplify sortable headers to show arrow only when active
- update list templates with AJAX containers
- redesign user detail page with cards and recent activity table
- filter audit logs by user and limit profile logs to 10
- document workflow improvements

## Testing
- `pip install -q -r requirements.txt`
- `python erp_project/manage.py test accounts`

------
https://chatgpt.com/codex/tasks/task_e_685534a5d5b88324a36e8a5892c4e1d7