### PR TITLE
Fix audit log actor filtering

### DIFF
--- a/docs/api/auditlog.md
+++ b/docs/api/auditlog.md
@@ -5,6 +5,7 @@
 - **Method:** `GET`
 - **Auth:** Logged in users with `view_auditlog` permission or superuser.
 - **Description:** Shows latest 100 audit log entries. Non-superusers only see logs from their company.
+- **Query Params:** `q` search string, `request_type` filter, `actor` filter, `sort` field (`-field` for descending), `page` for pagination
 - **Response:** HTML table with timestamp, user, action, request type, target user, and company.
 
 ## Log Detail

--- a/docs/api/onboarding.md
+++ b/docs/api/onboarding.md
@@ -48,7 +48,7 @@
 - **URL:** `/audit-logs/`
 - **Method:** `GET`
 - **Auth:** Auditor or Superuser
-- **Query Params:** `q` search string, `request_type` filter, `sort` field (`-field` for descending), `page` for pagination
+- **Query Params:** `q` search string, `request_type` filter, `actor` filter, `sort` field (`-field` for descending), `page` for pagination
 
 ## Create Company User
 - **URL:** `/companies/<id>/users/add/`

--- a/erp_project/accounts/tests.py
+++ b/erp_project/accounts/tests.py
@@ -452,6 +452,14 @@ class AuditLogListTests(TestCase):
         self.assertEqual(resp.context['page_obj'].paginator.count, 1)
         self.assertContains(resp, 'x')
 
+    def test_actor_filter(self):
+        other = User.objects.create_user(username='o1', password='pass', company=self.company1)
+        log_action(other, 'z', request_type='GET', company=self.company1)
+        self.client.login(username='u1', password='pass')
+        resp = self.client.get(reverse('audit_log_list'), {'actor': other.id})
+        self.assertEqual(resp.context['page_obj'].paginator.count, 1)
+        self.assertContains(resp, 'z')
+
 
 class AuditLogDetailTests(TestCase):
     def setUp(self):

--- a/erp_project/accounts/views.py
+++ b/erp_project/accounts/views.py
@@ -209,7 +209,7 @@ class UserDetailView(LoginRequiredMixin, DetailView):
             context['permissions'] = perms.values_list('codename', flat=True)
         if user_has_permission(req_user, 'view_auditlog'):
             context['logs'] = AuditLog.objects.filter(actor=target).order_by('-timestamp')[:10]
-            context['all_logs_url'] = reverse_lazy('audit_log_list') + f'?target_user={target.id}'
+            context['all_logs_url'] = reverse_lazy('audit_log_list') + f'?actor={target.id}'
         return context
 
 @method_decorator(require_permission('change_user'), name='dispatch')
@@ -383,7 +383,7 @@ class AuditLogListView(LoginRequiredMixin, AdvancedListMixin, TemplateView):
     template_name = 'audit_log_list.html'
     model = AuditLog
     search_fields = ['actor__username', 'action', 'request_type', 'company__name']
-    filter_fields = ['request_type', 'target_user']
+    filter_fields = ['request_type', 'actor']
     default_sort = '-timestamp'
 
     def base_queryset(self):
@@ -404,7 +404,7 @@ class AuditLogListView(LoginRequiredMixin, AdvancedListMixin, TemplateView):
             ('action', 'Action'),
             ('request_type', 'Type'),
         ]
-        users_qs = self.base_queryset().values_list('target_user', flat=True).distinct()
+        users_qs = self.base_queryset().values_list('actor', flat=True).distinct()
         user_options = [{'val': '', 'label': 'All'}]
         for uid in users_qs:
             if uid:
@@ -425,9 +425,9 @@ class AuditLogListView(LoginRequiredMixin, AdvancedListMixin, TemplateView):
                 ],
             },
             {
-                'name': 'target_user',
+                'name': 'actor',
                 'label': 'User',
-                'current': self.request.GET.get('target_user', ''),
+                'current': self.request.GET.get('actor', ''),
                 'options': user_options,
             },
         ]


### PR DESCRIPTION
## Summary
- fix `UserDetailView` log URL to filter by actor
- switch audit log list filter from `target_user` to `actor`
- document new `actor` filter parameter
- test actor filter functionality

## Testing
- `python erp_project/manage.py test accounts -v 2`

------
https://chatgpt.com/codex/tasks/task_e_68553a059ebc8324bf02c05c1b1454fd