### PR TITLE
Fix audit log actor filter and permission check

### DIFF
--- a/docs/api/auditlog.md
+++ b/docs/api/auditlog.md
@@ -6,6 +6,7 @@
 - **Auth:** Logged in users with `view_auditlog` permission or superuser.
 - **Description:** Shows latest 100 audit log entries. Non-superusers only see logs from their company.
 - **Query Params:** `q` search string, `request_type` filter, `actor` filter, `sort` field (`-field` for descending), `page` for pagination
+- **User Filter:** When viewing the log list the actor filter includes all users in the current company (all users if superuser), even if they have no log entries yet.
 - **Response:** HTML table with timestamp, user, action, request type, target user, and company.
 
 ## Log Detail

--- a/workflow.md
+++ b/workflow.md
@@ -118,6 +118,7 @@ Here’s your **expanded checklist** including **CRUD views, session/auth, and a
 | 37 | **Audit Logging Middleware for all requests**                 | ✅ Implemented by Agent |
 | 38 | **Role Management (list/create/update) UI & API**             | ✅ Implemented by Agent |
 | 39 | **Audit Log list view with filtering**                        | ✅ Implemented by Agent |
+|    | *(2024-??)* Actor filter updated to list all users in the company. | |
 | 40 | **Audit Log detail view with formatted JSON**                 | ✅ Implemented by Agent |
 
 ---


### PR DESCRIPTION
## Summary
- show all users in AuditLogListView filter
- ensure UserDetailView enforces company check and uses requesting user for permissions
- clarify audit log docs
- note workflow update
- add regression tests

## Testing
- `python erp_project/manage.py test accounts`

------
https://chatgpt.com/codex/tasks/task_e_68553d8a74688324aaa57b44bde0c60e