### PR TITLE
Remove has_permission filter usage

### DIFF
--- a/erp_project/accounts/context_processors.py
+++ b/erp_project/accounts/context_processors.py
@@ -1,0 +1,24 @@
+from types import SimpleNamespace
+from .utils import user_has_permission
+
+
+def nav_permissions(request):
+    """Return permission flags for navigation menu items."""
+    if not request.user.is_authenticated or not getattr(request.user, 'company', None):
+        return {}
+    codes = [
+        'view_user',
+        'view_role',
+        'view_warehouse',
+        'view_productcategory',
+        'view_productunit',
+        'view_product',
+        'view_stocklot',
+        'view_stockmovement',
+        'view_inventoryadjustment',
+        'view_stock_on_hand',
+        'view_auditlog',
+    ]
+    perms = {code: user_has_permission(request.user, code) for code in codes}
+    return {'nav_perms': SimpleNamespace(**perms)}
+

--- a/erp_project/accounts/tests.py
+++ b/erp_project/accounts/tests.py
@@ -589,3 +589,16 @@ class ProfilePictureDisplayTests(TestCase):
         self.assertContains(detail_resp, user.profile_picture.url)
 
 
+class TemplatePermissionFilterTests(TestCase):
+    def test_templates_do_not_use_has_permission_filter(self):
+        from pathlib import Path
+        from django.conf import settings
+
+        template_root = settings.BASE_DIR / 'templates'
+        for tpl in template_root.rglob('*.html'):
+            with self.subTest(template=tpl.name):
+                content = tpl.read_text()
+                self.assertNotIn('|has_permission', content)
+
+
+

--- a/erp_project/accounts/views.py
+++ b/erp_project/accounts/views.py
@@ -44,6 +44,7 @@ class CompanyListView(LoginRequiredMixin, SuperuserRequiredMixin, AdvancedListMi
         ]
         context['query_string'] = self.query_string()
         context['sort_query_string'] = self.sort_query_string()
+        context['can_add_user'] = user_has_permission(self.request.user, 'add_user')
         return context
 
 class DashboardView(LoginRequiredMixin, TemplateView):
@@ -341,6 +342,8 @@ class RoleListView(LoginRequiredMixin, AdvancedListMixin, TemplateView):
         ]
         context['query_string'] = self.query_string()
         context['sort_query_string'] = self.sort_query_string()
+        context['can_add_role'] = user_has_permission(self.request.user, 'add_role')
+        context['can_change_role'] = user_has_permission(self.request.user, 'change_role')
         return context
 
 

--- a/erp_project/erp_project/settings.py
+++ b/erp_project/erp_project/settings.py
@@ -64,6 +64,7 @@ TEMPLATES = [
                 'django.template.context_processors.request',
                 'django.contrib.auth.context_processors.auth',
                 'django.contrib.messages.context_processors.messages',
+                'accounts.context_processors.nav_permissions',
             ],
         },
     },

--- a/erp_project/inventory/views.py
+++ b/erp_project/inventory/views.py
@@ -40,6 +40,7 @@ class WarehouseListView(AdvancedListMixin, TemplateView):
         ]
         context['query_string'] = self.query_string()
         context['sort_query_string'] = self.sort_query_string()
+        context['can_add_warehouse'] = user_has_permission(self.request.user, 'add_warehouse')
         return context
 
 
@@ -89,6 +90,7 @@ class ProductCategoryListView(AdvancedListMixin, TemplateView):
         context['sort_options'] = [('name', 'Name')]
         context['query_string'] = self.query_string()
         context['sort_query_string'] = self.sort_query_string()
+        context['can_add_category'] = user_has_permission(self.request.user, 'add_productcategory')
         return context
 
 
@@ -148,6 +150,7 @@ class ProductUnitListView(AdvancedListMixin, TemplateView):
         context['sort_options'] = [('code', 'Code'), ('name', 'Name')]
         context['query_string'] = self.query_string()
         context['sort_query_string'] = self.sort_query_string()
+        context['can_add_unit'] = user_has_permission(self.request.user, 'add_productunit')
         return context
 
 
@@ -185,6 +188,7 @@ class ProductListView(AdvancedListMixin, TemplateView):
         context['sort_options'] = [('name', 'Name'), ('sku', 'SKU')]
         context['query_string'] = self.query_string()
         context['sort_query_string'] = self.sort_query_string()
+        context['can_add_product'] = user_has_permission(self.request.user, 'add_product')
         return context
 
 
@@ -242,6 +246,7 @@ class StockLotListView(AdvancedListMixin, TemplateView):
         context['sort_options'] = [('batch_number', 'Batch')]
         context['query_string'] = self.query_string()
         context['sort_query_string'] = self.sort_query_string()
+        context['can_add_stocklot'] = user_has_permission(self.request.user, 'add_stocklot')
         return context
 
 
@@ -291,6 +296,7 @@ class StockMovementListView(AdvancedListMixin, TemplateView):
         context['sort_options'] = [('date', 'Date')]
         context['query_string'] = self.query_string()
         context['sort_query_string'] = self.sort_query_string()
+        context['can_add_stockmovement'] = user_has_permission(self.request.user, 'add_stockmovement')
         return context
 
 
@@ -348,6 +354,7 @@ class InventoryAdjustmentListView(AdvancedListMixin, TemplateView):
         context['sort_options'] = [('date', 'Date')]
         context['query_string'] = self.query_string()
         context['sort_query_string'] = self.sort_query_string()
+        context['can_add_inventoryadjustment'] = user_has_permission(self.request.user, 'add_inventoryadjustment')
         return context
 
 

--- a/erp_project/templates/base.html
+++ b/erp_project/templates/base.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html>
-{% load permissions_tags %}
+
 <head>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
   <title>{% block title %}ERP{% endblock %}</title>
@@ -15,37 +15,37 @@
         <li class="nav-item"><a class="nav-link" href="{% url 'company_list' %}">Companies</a></li>
         <li class="nav-item"><a class="nav-link" href="{% url 'company_add' %}">Add Company</a></li>
         {% endif %}
-        {% if user.is_authenticated and user.company and user|has_permission:'view_user' %}
+        {% if user.is_authenticated and user.company and nav_perms.view_user %}
         <li class="nav-item"><a class="nav-link" href="{% url 'user_list' user.company.id %}">Users</a></li>
         {% endif %}
-        {% if user.is_authenticated and user.company and user|has_permission:'view_role' %}
+        {% if user.is_authenticated and user.company and nav_perms.view_role %}
         <li class="nav-item"><a class="nav-link" href="{% url 'role_list' %}">Roles</a></li>
         {% endif %}
-        {% if user.is_authenticated and user.company and user|has_permission:'view_warehouse' %}
+        {% if user.is_authenticated and user.company and nav_perms.view_warehouse %}
         <li class="nav-item"><a class="nav-link" href="{% url 'warehouse_list' %}">Warehouses</a></li>
         {% endif %}
-        {% if user.is_authenticated and user.company and user|has_permission:'view_productcategory' %}
+        {% if user.is_authenticated and user.company and nav_perms.view_productcategory %}
         <li class="nav-item"><a class="nav-link" href="{% url 'category_list' %}">Categories</a></li>
         {% endif %}
-        {% if user.is_authenticated and user.company and user|has_permission:'view_productunit' %}
+        {% if user.is_authenticated and user.company and nav_perms.view_productunit %}
         <li class="nav-item"><a class="nav-link" href="{% url 'unit_list' %}">Units</a></li>
         {% endif %}
-        {% if user.is_authenticated and user.company and user|has_permission:'view_product' %}
+        {% if user.is_authenticated and user.company and nav_perms.view_product %}
         <li class="nav-item"><a class="nav-link" href="{% url 'product_list' %}">Products</a></li>
         {% endif %}
-        {% if user.is_authenticated and user.company and user|has_permission:'view_stocklot' %}
+        {% if user.is_authenticated and user.company and nav_perms.view_stocklot %}
         <li class="nav-item"><a class="nav-link" href="{% url 'stock_lot_list' %}">Stock Lots</a></li>
         {% endif %}
-        {% if user.is_authenticated and user.company and user|has_permission:'view_stockmovement' %}
+        {% if user.is_authenticated and user.company and nav_perms.view_stockmovement %}
         <li class="nav-item"><a class="nav-link" href="{% url 'stock_movement_list' %}">Stock Movements</a></li>
         {% endif %}
-        {% if user.is_authenticated and user.company and user|has_permission:'view_inventoryadjustment' %}
+        {% if user.is_authenticated and user.company and nav_perms.view_inventoryadjustment %}
         <li class="nav-item"><a class="nav-link" href="{% url 'inventory_adjustment_list' %}">Adjustments</a></li>
         {% endif %}
-        {% if user.is_authenticated and user.company and user|has_permission:'view_stock_on_hand' %}
+        {% if user.is_authenticated and user.company and nav_perms.view_stock_on_hand %}
         <li class="nav-item"><a class="nav-link" href="{% url 'stock_on_hand' %}">Stock On Hand</a></li>
         {% endif %}
-        {% if user.is_authenticated and user|has_permission:'view_auditlog' %}
+        {% if user.is_authenticated and nav_perms.view_auditlog %}
         <li class="nav-item"><a class="nav-link" href="{% url 'audit_log_list' %}">Audit Logs</a></li>
         {% endif %}
       </ul>

--- a/erp_project/templates/category_list.html
+++ b/erp_project/templates/category_list.html
@@ -2,7 +2,7 @@
 {% block title %}Categories{% endblock %}
 {% block content %}
 <h2>Product Categories</h2>
-{% if user|has_permission:'add_productcategory' %}
+{% if can_add_category %}
 <a href="{% url 'category_add' %}" class="btn btn-success mb-2">Add Category</a>
 {% endif %}
 {% include 'includes/filter_form.html' %}

--- a/erp_project/templates/company_detail.html
+++ b/erp_project/templates/company_detail.html
@@ -1,5 +1,4 @@
 {% extends 'base.html' %}
-{% load permissions_tags %}
 {% block title %}Company Detail{% endblock %}
 {% block content %}
 <h2>{{ object.name }}</h2>

--- a/erp_project/templates/inventory_adjustment_list.html
+++ b/erp_project/templates/inventory_adjustment_list.html
@@ -2,7 +2,7 @@
 {% block title %}Inventory Adjustments{% endblock %}
 {% block content %}
 <h2>Inventory Adjustments</h2>
-{% if user|has_permission:'add_inventoryadjustment' %}
+{% if can_add_inventoryadjustment %}
 <a href="{% url 'inventory_adjustment_add' %}" class="btn btn-success mb-2">Add Adjustment</a>
 {% endif %}
 <table class="table">

--- a/erp_project/templates/product_list.html
+++ b/erp_project/templates/product_list.html
@@ -2,7 +2,7 @@
 {% block title %}Products{% endblock %}
 {% block content %}
 <h2>Products</h2>
-{% if user|has_permission:'add_product' %}
+{% if can_add_product %}
 <a href="{% url 'product_add' %}" class="btn btn-success mb-2">Add Product</a>
 {% endif %}
 {% include 'includes/filter_form.html' %}

--- a/erp_project/templates/product_unit_list.html
+++ b/erp_project/templates/product_unit_list.html
@@ -2,7 +2,7 @@
 {% block title %}Units{% endblock %}
 {% block content %}
 <h2>Product Units</h2>
-{% if user|has_permission:'add_productunit' %}
+{% if can_add_unit %}
 <a href="{% url 'unit_add' %}" class="btn btn-success mb-2">Add Unit</a>
 {% endif %}
 {% include 'includes/filter_form.html' %}

--- a/erp_project/templates/role_list.html
+++ b/erp_project/templates/role_list.html
@@ -1,9 +1,8 @@
 {% extends 'base.html' %}
-{% load permissions_tags %}
 {% block title %}Roles{% endblock %}
 {% block content %}
 <h2>Roles for {{ request.user.company.name }}</h2>
-{% if user|has_permission:'add_role' %}
+{% if can_add_role %}
 <a href="{% url 'role_add' %}" class="btn btn-success mb-2">Add Role</a>
 {% endif %}
 {% include 'includes/filter_form.html' %}
@@ -22,7 +21,7 @@
     <td>{{ r.name }}</td>
     <td>{{ r.description }}</td>
     <td>
-      {% if user|has_permission:'change_role' %}
+      {% if can_change_role %}
       <a href="{% url 'role_edit' r.id %}" class="btn btn-sm btn-primary">Edit</a>
       {% endif %}
     </td>

--- a/erp_project/templates/stock_lot_list.html
+++ b/erp_project/templates/stock_lot_list.html
@@ -2,7 +2,7 @@
 {% block title %}Stock Lots{% endblock %}
 {% block content %}
 <h2>Stock Lots</h2>
-{% if user|has_permission:'add_stocklot' %}
+{% if can_add_stocklot %}
 <a href="{% url 'stock_lot_add' %}" class="btn btn-success mb-2">Add Lot</a>
 {% endif %}
 {% include 'includes/filter_form.html' %}

--- a/erp_project/templates/stock_movement_list.html
+++ b/erp_project/templates/stock_movement_list.html
@@ -2,7 +2,7 @@
 {% block title %}Stock Movements{% endblock %}
 {% block content %}
 <h2>Stock Movements</h2>
-{% if user|has_permission:'add_stockmovement' %}
+{% if can_add_stockmovement %}
 <a href="{% url 'stock_movement_add' %}" class="btn btn-success mb-2">Add Movement</a>
 {% endif %}
 {% include 'includes/filter_form.html' %}

--- a/erp_project/templates/user_list.html
+++ b/erp_project/templates/user_list.html
@@ -1,9 +1,8 @@
 {% extends 'base.html' %}
-{% load permissions_tags %}
 {% block title %}Users{% endblock %}
 {% block content %}
 <h2>Users for {{ company.name }}</h2>
-{% if user|has_permission:'add_user' %}
+{% if can_add_user %}
 <a href="{% url 'user_add' company.id %}" class="btn btn-success mb-2">Add User</a>
 {% endif %}
 {% include 'includes/filter_form.html' %}

--- a/erp_project/templates/warehouse_list.html
+++ b/erp_project/templates/warehouse_list.html
@@ -2,7 +2,7 @@
 {% block title %}Warehouses{% endblock %}
 {% block content %}
 <h2>Warehouses</h2>
-{% if user|has_permission:'add_warehouse' %}
+{% if can_add_warehouse %}
 <a href="{% url 'warehouse_add' %}" class="btn btn-success mb-2">Add Warehouse</a>
 {% endif %}
 {% include 'includes/filter_form.html' %}


### PR DESCRIPTION
## Summary
- remove `has_permission` filter usage from all templates
- add nav permission context processor and update settings
- compute permission flags in views
- test to ensure no templates use `|has_permission`

## Testing
- `python erp_project/manage.py test accounts.tests.TemplatePermissionFilterTests.test_templates_do_not_use_has_permission_filter -v 2`

------
https://chatgpt.com/codex/tasks/task_e_68558530c0388324a5abd12a95c33b49