### PR TITLE
Fix default filters in forms and add template sanity test

### DIFF
--- a/erp_project/templates/category_form.html
+++ b/erp_project/templates/category_form.html
@@ -1,21 +1,20 @@
 {% extends 'base.html' %}
 {% block title %}Category{% endblock %}
 {% block content %}
-<h2>{% if form.instance.pk %}Edit{% else %}Add{% endif %} Category</h2>
+<h2>{% if category %}Edit{% else %}Add{% endif %} Category</h2>
 <form method="post" class="needs-validation" novalidate>
   {% csrf_token %}
   <div class="mb-3">
     <label for="id_name" class="form-label">Name</label>
-    <input type="text" name="name" id="id_name" class="form-control" value="{{ form.name.value|default:'' }}" required>
-    {% if error and not form.name %}<div class="invalid-feedback">{{ error }}</div>{% endif %}
-    {% for e in form.name.errors %}<div class="invalid-feedback">{{ e }}</div>{% endfor %}
+    <input type="text" name="name" id="id_name" class="form-control" value="{{ name }}" required>
+    {% if error %}<div class="invalid-feedback">{{ error }}</div>{% endif %}
   </div>
   <div class="mb-3">
     <label for="id_parent" class="form-label">Parent</label>
     <select name="parent" id="id_parent" class="form-select">
       <option value="">----</option>
       {% for c in categories %}
-      <option value="{{ c.id }}" {% if form.parent.value|stringformat:'s' == c.id|stringformat:'s' %}selected{% endif %}>{{ c.name }}</option>
+      <option value="{{ c.id }}" {% if parent|stringformat:'s' == c.id|stringformat:'s' %}selected{% endif %}>{{ c.name }}</option>
       {% endfor %}
     </select>
   </div>

--- a/erp_project/templates/company_form.html
+++ b/erp_project/templates/company_form.html
@@ -6,21 +6,21 @@
   {% csrf_token %}
   <div class="mb-3">
     <label for="id_name" class="form-label">Name</label>
-    <input type="text" name="name" id="id_name" class="form-control" value="{{ form.name.value|default:'' }}" required>
+    <input type="text" name="name" id="id_name" class="form-control" value="{{ name }}" required>
     {% for error in form.name.errors %}
       <div class="invalid-feedback">{{ error }}</div>
     {% endfor %}
   </div>
   <div class="mb-3">
     <label for="id_code" class="form-label">Code</label>
-    <input type="text" name="code" id="id_code" class="form-control" value="{{ form.code.value|default:'' }}" required>
+    <input type="text" name="code" id="id_code" class="form-control" value="{{ code }}" required>
     {% for error in form.code.errors %}
       <div class="invalid-feedback">{{ error }}</div>
     {% endfor %}
   </div>
   <div class="mb-3">
     <label for="id_address" class="form-label">Address</label>
-    <input type="text" name="address" id="id_address" class="form-control" value="{{ form.address.value|default:'' }}">
+    <input type="text" name="address" id="id_address" class="form-control" value="{{ address }}">
     {% for error in form.address.errors %}
       <div class="invalid-feedback">{{ error }}</div>
     {% endfor %}

--- a/erp_project/templates/product_unit_form.html
+++ b/erp_project/templates/product_unit_form.html
@@ -6,11 +6,11 @@
   {% csrf_token %}
   <div class="mb-3">
     <label for="id_code" class="form-label">Code</label>
-    <input type="text" name="code" id="id_code" class="form-control" value="{{ code|default:'' }}" required>
+    <input type="text" name="code" id="id_code" class="form-control" value="{{ code }}" required>
   </div>
   <div class="mb-3">
     <label for="id_name" class="form-label">Name</label>
-    <input type="text" name="name" id="id_name" class="form-control" value="{{ name|default:'' }}" required>
+    <input type="text" name="name" id="id_name" class="form-control" value="{{ name }}" required>
   </div>
   {% if error %}<div class="alert alert-danger">{{ error }}</div>{% endif %}
   <button type="submit" class="btn btn-success">Save</button>

--- a/erp_project/templates/role_form.html
+++ b/erp_project/templates/role_form.html
@@ -7,11 +7,11 @@
   {% csrf_token %}
   <div class="mb-3">
     <label for="id_name" class="form-label">Name</label>
-    <input type="text" name="name" id="id_name" class="form-control" value="{{ role.name|default:'' }}" required>
+    <input type="text" name="name" id="id_name" class="form-control" value="{{ name }}" required>
   </div>
   <div class="mb-3">
     <label for="id_description" class="form-label">Description</label>
-    <input type="text" name="description" id="id_description" class="form-control" value="{{ role.description|default:'' }}">
+    <input type="text" name="description" id="id_description" class="form-control" value="{{ description }}">
   </div>
   <div class="mb-3">
     <label class="form-label">Permissions</label><br>

--- a/erp_project/templates/user_form.html
+++ b/erp_project/templates/user_form.html
@@ -6,28 +6,28 @@
   {% csrf_token %}
   <div class="mb-3">
     <label for="id_username" class="form-label">Username</label>
-    <input type="text" name="username" id="id_username" class="form-control" value="{{ form.username.value|default:'' }}" required>
+    <input type="text" name="username" id="id_username" class="form-control" value="{{ username }}" required>
     {% for error in form.username.errors %}
       <div class="invalid-feedback">{{ error }}</div>
     {% endfor %}
   </div>
   <div class="mb-3">
     <label for="id_email" class="form-label">Email</label>
-    <input type="email" name="email" id="id_email" class="form-control" value="{{ form.email.value|default:'' }}">
+    <input type="email" name="email" id="id_email" class="form-control" value="{{ email }}">
     {% for error in form.email.errors %}
       <div class="invalid-feedback">{{ error }}</div>
     {% endfor %}
   </div>
   <div class="mb-3">
     <label for="id_first_name" class="form-label">First name</label>
-    <input type="text" name="first_name" id="id_first_name" class="form-control" value="{{ form.first_name.value|default:'' }}">
+    <input type="text" name="first_name" id="id_first_name" class="form-control" value="{{ first_name }}">
     {% for error in form.first_name.errors %}
       <div class="invalid-feedback">{{ error }}</div>
     {% endfor %}
   </div>
   <div class="mb-3">
     <label for="id_last_name" class="form-label">Last name</label>
-    <input type="text" name="last_name" id="id_last_name" class="form-control" value="{{ form.last_name.value|default:'' }}">
+    <input type="text" name="last_name" id="id_last_name" class="form-control" value="{{ last_name }}">
     {% for error in form.last_name.errors %}
       <div class="invalid-feedback">{{ error }}</div>
     {% endfor %}

--- a/erp_project/templates/warehouse_form.html
+++ b/erp_project/templates/warehouse_form.html
@@ -1,18 +1,17 @@
 {% extends 'base.html' %}
 {% block title %}Warehouse{% endblock %}
 {% block content %}
-<h2>{% if form.instance.pk %}Edit{% else %}Add{% endif %} Warehouse</h2>
+<h2>{% if warehouse %}Edit{% else %}Add{% endif %} Warehouse</h2>
 <form method="post" class="needs-validation" novalidate>
   {% csrf_token %}
   <div class="mb-3">
     <label for="id_name" class="form-label">Name</label>
-    <input type="text" name="name" id="id_name" class="form-control" value="{{ form.name.value|default:name }}" required>
-    {% if error and not form.name %}<div class="invalid-feedback">{{ error }}</div>{% endif %}
-    {% for e in form.name.errors %}<div class="invalid-feedback">{{ e }}</div>{% endfor %}
+    <input type="text" name="name" id="id_name" class="form-control" value="{{ name }}" required>
+    {% if error %}<div class="invalid-feedback">{{ error }}</div>{% endif %}
   </div>
   <div class="mb-3">
     <label for="id_location" class="form-label">Location</label>
-    <input type="text" name="location" id="id_location" class="form-control" value="{{ form.location.value|default:location }}">
+    <input type="text" name="location" id="id_location" class="form-control" value="{{ location }}">
   </div>
   <button type="submit" class="btn btn-success">Save</button>
 </form>


### PR DESCRIPTION
## Summary
- remove default filter usage in various form templates
- supply corresponding values from backend views
- add a test scanning templates for pipes in value attributes

## Testing
- `python manage.py test inventory`

------
https://chatgpt.com/codex/tasks/task_e_68564ad20ab4832485bb890c5fd117f2