### PR TITLE
Implement hierarchical category form

### DIFF
--- a/docs/api/inventory.md
+++ b/docs/api/inventory.md
@@ -51,6 +51,13 @@
 - **Auth:** `delete_productcategory`
 - **Response:** `204 No Content`
 
+### Category Children
+- **URL:** `/inventory/categories/children/`
+- **Method:** `GET`
+- **Auth:** `view_productcategory`
+- **Params:** `parent` (optional category id), `level` (next level number)
+- **Response:** HTML snippet with a select for child categories
+
 ## List Units
 - **URL:** `/inventory/units/`
 - **Method:** `GET`

--- a/erp_project/inventory/tests.py
+++ b/erp_project/inventory/tests.py
@@ -69,6 +69,13 @@ class CategoryViewTests(TestCase):
         resp = self.client.get(reverse('category_edit', args=[cat.id]))
         self.assertContains(resp, 'value="Old"')
 
+    def test_category_children_endpoint(self):
+        parent = ProductCategory.objects.create(name='Root', company=self.company)
+        ProductCategory.objects.create(name='Child', parent=parent, company=self.company)
+        resp = self.client.get(reverse('category_children'), {'parent': parent.id, 'level': 2})
+        self.assertEqual(resp.status_code, 200)
+        self.assertContains(resp, 'Child')
+
 
 class CategoryTreeTests(TestCase):
     def setUp(self):

--- a/erp_project/inventory/urls.py
+++ b/erp_project/inventory/urls.py
@@ -2,7 +2,7 @@ from django.urls import path
 from .views import (
     WarehouseListView, WarehouseCreateView, WarehouseUpdateView,
     ProductCategoryListView, ProductCategoryCreateView, ProductCategoryUpdateView,
-    CategoryTreeView, category_rename, category_move, category_delete,
+    CategoryTreeView, category_rename, category_move, category_delete, category_children,
     ProductUnitListView, ProductUnitCreateView,
     ProductListView, ProductCreateView,
     StockLotListView, StockLotCreateView,
@@ -22,6 +22,7 @@ urlpatterns = [
     path('categories/<int:pk>/rename/', category_rename, name='category_rename'),
     path('categories/<int:pk>/move/', category_move, name='category_move'),
     path('categories/<int:pk>/delete/', category_delete, name='category_delete'),
+    path('categories/children/', category_children, name='category_children'),
     path('units/', ProductUnitListView.as_view(), name='unit_list'),
     path('units/add/', ProductUnitCreateView.as_view(), name='unit_add'),
     path('products/', ProductListView.as_view(), name='product_list'),

--- a/erp_project/templates/category_form.html
+++ b/erp_project/templates/category_form.html
@@ -9,15 +9,38 @@
     <input type="text" name="name" id="id_name" class="form-control" value="{{ name }}" required>
     {% if error %}<div class="invalid-feedback">{{ error }}</div>{% endif %}
   </div>
-  <div class="mb-3">
-    <label for="id_parent" class="form-label">Parent</label>
-    <select name="parent" id="id_parent" class="form-select">
-      <option value="">----</option>
-      {% for c in categories %}
-      <option value="{{ c.id }}" {% if parent|stringformat:'s' == c.id|stringformat:'s' %}selected{% endif %}>{{ c.name }}</option>
-      {% endfor %}
-    </select>
+  <input type="hidden" name="parent" id="id_parent_hidden" value="{{ parent }}">
+  <div id="category-selects">
+    <div class="mb-3" id="level-1">
+      <label class="form-label">Level 1 Category</label>
+      <select name="parent" class="form-select category-select" data-level="1"
+              hx-get="{% url 'category_children' %}?level=2" hx-target="#level-2" hx-trigger="change">
+        <option value="">-- None --</option>
+        {% for c in root_categories %}
+        <option value="{{ c.id }}" {% if parent|stringformat:'s' == c.id|stringformat:'s' %}selected{% endif %}>{{ c.name }}</option>
+        {% endfor %}
+      </select>
+    </div>
+    <div id="level-2"></div>
   </div>
   <button type="submit" class="btn btn-success">Save</button>
 </form>
+<script>
+function updateParent(){
+  let val='';
+  document.querySelectorAll('.category-select').forEach(s=>{if(s.value){val=s.value;}});
+  document.getElementById('id_parent_hidden').value=val;
+}
+updateParent();
+
+document.getElementById('category-selects').addEventListener('change',function(e){
+  if(e.target.classList.contains('category-select')){
+    const level=parseInt(e.target.dataset.level);
+    document.querySelectorAll('.category-select').forEach(sel=>{
+      if(parseInt(sel.dataset.level)>level){sel.parentElement.remove();}
+    });
+    updateParent();
+  }
+});
+</script>
 {% endblock %}

--- a/erp_project/templates/includes/category_select.html
+++ b/erp_project/templates/includes/category_select.html
@@ -1,0 +1,11 @@
+<div class="mb-3" id="level-{{ level }}">
+  <label class="form-label">Level {{ level }} Category</label>
+  <select name="parent" class="form-select category-select" data-level="{{ level }}"
+          hx-get="{% url 'category_children' %}?level={{ level|add:'1' }}" hx-target="#level-{{ level|add:'1' }}" hx-trigger="change">
+    <option value="">-- None --</option>
+    {% for c in categories %}
+    <option value="{{ c.id }}">{{ c.name }}</option>
+    {% endfor %}
+  </select>
+</div>
+<div id="level-{{ level|add:'1' }}"></div>

--- a/workflow.md
+++ b/workflow.md
@@ -244,6 +244,7 @@ After this workflow:
 | 12 | **API Documentation for all endpoints**            | ✅ Implemented by Agent |
 | 13 | **Integration/UI Tests for full workflow**         | ✅ Implemented by Agent |
 | 14 | **Category Tree management UI**                    | ✅ Implemented by Agent |
+| 15 | **Hierarchical Category Selection in Forms**       | ✅ Implemented by Agent |
 
 ---
 


### PR DESCRIPTION
## Summary
- add dynamic endpoint to fetch child categories
- update category form to support multi-level selection
- document new `category_children` API endpoint
- update workflow checklist
- test new endpoint

## Testing
- `python erp_project/manage.py test inventory accounts -v 1`

------
https://chatgpt.com/codex/tasks/task_e_685654bfb75483249518086efd098433