### PR TITLE
Improve product category creation workflow

### DIFF
--- a/docs/api/inventory.md
+++ b/docs/api/inventory.md
@@ -25,6 +25,13 @@
 - **Payload:** `name`, `parent` (optional)
 - **Response:** Redirect to category list
 
+### Quick Add Category
+- **URL:** `/inventory/categories/quick-add/`
+- **Method:** `POST`
+- **Auth:** `add_productcategory`
+- **Payload:** `name`, `parent` (optional)
+- **Response:** HTML `<option>` for the new category (201)
+
 ## Category Tree
 - **URL:** `/inventory/category-tree/`
 - **Method:** `GET`

--- a/erp_project/inventory/tests.py
+++ b/erp_project/inventory/tests.py
@@ -76,6 +76,11 @@ class CategoryViewTests(TestCase):
         self.assertEqual(resp.status_code, 200)
         self.assertContains(resp, 'Child')
 
+    def test_quick_add(self):
+        resp = self.client.post(reverse('category_quick_add'), {'name': 'Quick'})
+        self.assertEqual(resp.status_code, 201)
+        self.assertTrue(ProductCategory.objects.filter(name='Quick', company=self.company).exists())
+
 
 class CategoryTreeTests(TestCase):
     def setUp(self):

--- a/erp_project/inventory/urls.py
+++ b/erp_project/inventory/urls.py
@@ -2,7 +2,7 @@ from django.urls import path
 from .views import (
     WarehouseListView, WarehouseCreateView, WarehouseUpdateView,
     ProductCategoryListView, ProductCategoryCreateView, ProductCategoryUpdateView,
-    CategoryTreeView, category_rename, category_move, category_delete, category_children,
+    CategoryTreeView, category_rename, category_move, category_delete, category_children, category_quick_add,
     ProductUnitListView, ProductUnitCreateView,
     ProductListView, ProductCreateView,
     StockLotListView, StockLotCreateView,
@@ -23,6 +23,7 @@ urlpatterns = [
     path('categories/<int:pk>/move/', category_move, name='category_move'),
     path('categories/<int:pk>/delete/', category_delete, name='category_delete'),
     path('categories/children/', category_children, name='category_children'),
+    path('categories/quick-add/', category_quick_add, name='category_quick_add'),
     path('units/', ProductUnitListView.as_view(), name='unit_list'),
     path('units/add/', ProductUnitCreateView.as_view(), name='unit_add'),
     path('products/', ProductListView.as_view(), name='product_list'),

--- a/erp_project/inventory/views.py
+++ b/erp_project/inventory/views.py
@@ -290,6 +290,20 @@ def category_children(request):
     return render(request, 'includes/category_select.html', {'categories': cats, 'level': level})
 
 
+@require_permission('add_productcategory')
+def category_quick_add(request):
+    """Create a category via HTMX and return an option element."""
+    name = request.POST.get('name', '').strip()
+    if not name:
+        return HttpResponseBadRequest('Name required')
+    parent_id = request.POST.get('parent')
+    parent = None
+    if parent_id:
+        parent = get_object_or_404(ProductCategory, pk=parent_id, company=request.user.company)
+    category = ProductCategory.objects.create(name=name, parent=parent, company=request.user.company)
+    return render(request, 'includes/category_option.html', {'category': category}, status=201)
+
+
 @method_decorator(require_permission('view_productunit'), name='dispatch')
 class ProductUnitListView(AdvancedListMixin, TemplateView):
     template_name = 'product_unit_list.html'

--- a/erp_project/templates/category_form.html
+++ b/erp_project/templates/category_form.html
@@ -4,24 +4,28 @@
 <h2>{% if category %}Edit{% else %}Add{% endif %} Category</h2>
 <form method="post" class="needs-validation" novalidate>
   {% csrf_token %}
-  <div class="mb-3">
-    <label for="id_name" class="form-label">Name</label>
-    <input type="text" name="name" id="id_name" class="form-control" value="{{ name }}" required>
-    {% if error %}<div class="invalid-feedback">{{ error }}</div>{% endif %}
-  </div>
   <input type="hidden" name="parent" id="id_parent_hidden" value="{{ parent }}">
   <div id="category-selects">
     <div class="mb-3" id="level-1">
       <label class="form-label">Level 1 Category</label>
-      <select name="parent" class="form-select category-select" data-level="1"
-              hx-get="{% url 'category_children' %}?level=2" hx-target="#level-2" hx-trigger="change">
-        <option value="">-- None --</option>
-        {% for c in root_categories %}
-        <option value="{{ c.id }}" {% if parent|stringformat:'s' == c.id|stringformat:'s' %}selected{% endif %}>{{ c.name }}</option>
-        {% endfor %}
-      </select>
+      <div class="input-group">
+        <select name="parent" class="form-select category-select" data-level="1"
+                hx-get="{% url 'category_children' %}?level=2" hx-target="#level-2" hx-trigger="change">
+          <option value="">-- None --</option>
+          {% for c in root_categories %}
+          <option value="{{ c.id }}" {% if parent|stringformat:'s' == c.id|stringformat:'s' %}selected{% endif %}>{{ c.name }}</option>
+          {% endfor %}
+        </select>
+        <button type="button" class="btn btn-outline-secondary add-btn" data-level="1">Add</button>
+      </div>
+      <div class="add-container"></div>
     </div>
     <div id="level-2"></div>
+  </div>
+  <div class="mb-3">
+    <label for="id_name" class="form-label">Name</label>
+    <input type="text" name="name" id="id_name" class="form-control" value="{{ name }}" required>
+    {% if error %}<div class="invalid-feedback">{{ error }}</div>{% endif %}
   </div>
   <button type="submit" class="btn btn-success">Save</button>
 </form>
@@ -37,9 +41,31 @@ document.getElementById('category-selects').addEventListener('change',function(e
   if(e.target.classList.contains('category-select')){
     const level=parseInt(e.target.dataset.level);
     document.querySelectorAll('.category-select').forEach(sel=>{
-      if(parseInt(sel.dataset.level)>level){sel.parentElement.remove();}
+      if(parseInt(sel.dataset.level)>level){sel.closest('.mb-3').remove();}
     });
     updateParent();
+  }
+});
+
+const quickAddUrl = "{% url 'category_quick_add' %}";
+document.getElementById('category-selects').addEventListener('click',function(e){
+  if(e.target.classList.contains('add-btn')){
+    const level=e.target.dataset.level;
+    const wrapper=document.getElementById('level-'+level);
+    const select=wrapper.querySelector('select');
+    const parentVal=select.value;
+    wrapper.querySelector('.add-container').innerHTML=`<form class="add-form mt-2 d-flex" data-level="${level}" hx-post="${quickAddUrl}" hx-target="#level-${level} select" hx-swap="beforeend"><input type="hidden" name="parent" value="${parentVal}"><input type="text" name="name" class="form-control me-2" required><button class="btn btn-primary" type="submit">Add</button></form>`;
+  }
+});
+
+document.body.addEventListener('htmx:afterRequest',function(e){
+  if(e.target.classList.contains('add-form')){
+    const level=e.target.dataset.level;
+    const select=document.querySelector(`#level-${level} select`);
+    const opt=select.querySelector('option[selected]');
+    if(opt){select.value=opt.value;}
+    select.dispatchEvent(new Event('change'));
+    e.target.remove();
   }
 });
 </script>

--- a/erp_project/templates/includes/category_option.html
+++ b/erp_project/templates/includes/category_option.html
@@ -1,0 +1,1 @@
+<option value="{{ category.id }}" selected>{{ category.name }}</option>

--- a/erp_project/templates/includes/category_select.html
+++ b/erp_project/templates/includes/category_select.html
@@ -1,11 +1,15 @@
 <div class="mb-3" id="level-{{ level }}">
   <label class="form-label">Level {{ level }} Category</label>
-  <select name="parent" class="form-select category-select" data-level="{{ level }}"
-          hx-get="{% url 'category_children' %}?level={{ level|add:'1' }}" hx-target="#level-{{ level|add:'1' }}" hx-trigger="change">
-    <option value="">-- None --</option>
-    {% for c in categories %}
-    <option value="{{ c.id }}">{{ c.name }}</option>
-    {% endfor %}
-  </select>
+  <div class="input-group">
+    <select name="parent" class="form-select category-select" data-level="{{ level }}"
+            hx-get="{% url 'category_children' %}?level={{ level|add:'1' }}" hx-target="#level-{{ level|add:'1' }}" hx-trigger="change">
+      <option value="">-- None --</option>
+      {% for c in categories %}
+      <option value="{{ c.id }}">{{ c.name }}</option>
+      {% endfor %}
+    </select>
+    <button type="button" class="btn btn-outline-secondary add-btn" data-level="{{ level }}">Add</button>
+  </div>
+  <div class="add-container"></div>
 </div>
 <div id="level-{{ level|add:'1' }}"></div>


### PR DESCRIPTION
## Summary
- allow quick add of product categories via new endpoint
- include Add buttons in category select dropdowns
- reorder category form fields to choose parent category first
- document `category_quick_add` API endpoint
- test quick add view

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68565769dc9883249cdfb9741335ae59