### PR TITLE
Fix category creation when parent '__new__'

### DIFF
--- a/erp_project/inventory/tests.py
+++ b/erp_project/inventory/tests.py
@@ -62,6 +62,11 @@ class CategoryViewTests(TestCase):
         self.assertEqual(resp.status_code, 302)
         self.assertTrue(ProductCategory.objects.filter(name='Cat1', company=self.company).exists())
 
+    def test_create_category_ignores_new_parent_marker(self):
+        resp = self.client.post(reverse('category_add'), {'name': 'CatNew', 'parent': '__new__'})
+        self.assertEqual(resp.status_code, 302)
+        self.assertTrue(ProductCategory.objects.filter(name='CatNew', parent__isnull=True, company=self.company).exists())
+
     def test_duplicate_category_rejected(self):
         ProductCategory.objects.create(name='Unique', company=self.company)
         resp = self.client.post(reverse('category_add'), {'name': 'Unique'})

--- a/erp_project/inventory/views.py
+++ b/erp_project/inventory/views.py
@@ -146,7 +146,7 @@ class ProductCategoryCreateView(View):
         name = request.POST.get('name', '').strip()
         parent_id = request.POST.get('parent')
         parent = None
-        if parent_id:
+        if parent_id and parent_id.isdigit():
             parent = get_object_or_404(ProductCategory, pk=parent_id, company=request.user.company)
         if not name:
             roots = ProductCategory.objects.filter(
@@ -201,7 +201,7 @@ class ProductCategoryUpdateView(View):
         name = request.POST.get('name', '').strip()
         parent_id = request.POST.get('parent')
         parent = None
-        if parent_id:
+        if parent_id and parent_id.isdigit():
             parent = get_object_or_404(ProductCategory, pk=parent_id, company=request.user.company)
         if not name:
             roots = ProductCategory.objects.filter(
@@ -328,7 +328,7 @@ def category_quick_add(request):
         return HttpResponseBadRequest('Category with this name already exists')
     parent_id = request.POST.get('parent')
     parent = None
-    if parent_id:
+    if parent_id and parent_id.isdigit():
         parent = get_object_or_404(ProductCategory, pk=parent_id, company=request.user.company)
     category = ProductCategory.objects.create(name=name, parent=parent, company=request.user.company)
     return render(request, 'includes/category_option.html', {'category': category}, status=201)


### PR DESCRIPTION
## Summary
- handle special '__new__' value when creating or updating product categories
- ensure quick-add endpoint also validates numeric parent id
- add regression test for submitting category add form with '__new__'

## Testing
- `python erp_project/manage.py test inventory.tests`

------
https://chatgpt.com/codex/tasks/task_e_68565dc40614832488a070f514bbf804