### PR TITLE
Allow editing user permissions from update form

### DIFF
--- a/docs/api/onboarding.md
+++ b/docs/api/onboarding.md
@@ -72,7 +72,9 @@
 - **Payload:** standard user fields (`username`, `email`, etc.) plus `current_password` when self-editing.
 - **Files:** `profile_picture` optional image file.
 - **Audit:** all user edits are recorded in `AuditLog` entries.
-- **Notes:** new roles can be created during editing only when the user has `add_role` permission.
+- **Notes:**
+  - New roles can be created during editing only when the user has `add_role` permission.
+  - When the acting user has `change_role`, they may toggle the assigned role's permissions using a permissions grid.
 
 ## Role Management
 - **List Roles:** `GET /roles/`

--- a/erp_project/templates/user_form.html
+++ b/erp_project/templates/user_form.html
@@ -68,6 +68,12 @@
       {% if can_add_role %}<option value="new">Create new role...</option>{% endif %}
     </select>
   </div>
+  {% if can_change_role %}
+  <div class="mb-3">
+    <label class="form-label">Permissions</label>
+    {% include 'includes/permissions_grid.html' with permissions=permissions assigned_ids=assigned_ids %}
+  </div>
+  {% endif %}
   {% if can_add_role %}
   <div id="new-role-fields" style="display:none;" class="mb-3">
     <label for="id_new_role_name" class="form-label">New Role Name</label>

--- a/workflow.md
+++ b/workflow.md
@@ -140,6 +140,7 @@ Buttons are hidden unless the user has the appropriate permission.
 Added audit logging middleware to capture every authenticated request.
 Implemented role management screens and ability to change a user's role during edit.
 Creating a new role from the user form now requires the `add_role` permission.
+When a user has the `change_role` permission they can toggle the assigned role's permissions directly from the user edit page.
 User detail view now shows role, permissions, recent audit logs and profile pictures. User list supports search and pagination.
 Fixed profile picture display by configuring MEDIA_URL and MEDIA_ROOT.
 List views now share filter and pagination components. All list tables allow sorting by any column via reusable headers.


### PR DESCRIPTION
## Summary
- expose permission grid on User edit when viewer has `change_role`
- allow permission updates for existing roles during user edit
- document new capability in workflow and API docs
- test permission grid visibility and updates

## Testing
- `python manage.py test accounts.tests.ChangeRolePermissionTests --keepdb -v 2`
- `python manage.py test -v 2`


------
https://chatgpt.com/codex/tasks/task_e_6857d8d61a548324a9bd10cb31181395