### PR TITLE
Enable Select2 for supplier bank dropdown

### DIFF
--- a/docs/api/purchasing.md
+++ b/docs/api/purchasing.md
@@ -26,7 +26,7 @@
   - **Method:** `POST`
   - **Auth:** `add_supplier`
   - **Payload:** `name`, `contact_person`, `phone`, `email`, `trade_license_number`, `trn`, `iban`, `bank_name` (existing or new), `swift_code`, `address`
-  - **Notes:** `bank_name` is entered via a text field with suggestions from existing banks. The combination of bank name and SWIFT code must be unique and each supplier IBAN must be unique.
+  - **Notes:** `bank_name` is chosen using a Select2 dropdown that searches existing banks. Typing a new name will create a new bank record. The combination of bank name and SWIFT code must be unique and each supplier IBAN must be unique.
   - **Response:** Redirect to supplier detail page and sends OTP email
 
 - **Verify Supplier**

--- a/erp_project/purchasing/tests.py
+++ b/erp_project/purchasing/tests.py
@@ -398,4 +398,13 @@ class SupplierEnhancementTests(TestCase):
         })
         self.assertTrue(Bank.objects.filter(name='BrandNewBank').exists())
 
+    def test_supplier_form_uses_select2(self):
+        resp = self.client.get(reverse('supplier_add'))
+        self.assertContains(resp, 'select2')
+
+    def test_supplier_update_form_uses_select2(self):
+        supplier = Supplier.objects.create(name='S1', contact_person='CP', email='s1@example.com', phone='+10000000000', company=self.company)
+        resp = self.client.get(reverse('supplier_edit', args=[supplier.id]))
+        self.assertContains(resp, 'select2')
+
 

--- a/erp_project/templates/base.html
+++ b/erp_project/templates/base.html
@@ -3,6 +3,7 @@
 
 <head>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link href="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/css/select2.min.css" rel="stylesheet">
   <title>{% block title %}ERP{% endblock %}</title>
 </head>
 <body>
@@ -76,6 +77,8 @@
     {% endif %}
     {% block content %}{% endblock %}
   </div>
+  <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/js/select2.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
   {% block extra_js %}{% endblock %}
 </body>

--- a/erp_project/templates/supplier_form.html
+++ b/erp_project/templates/supplier_form.html
@@ -49,12 +49,11 @@
       </div>
       <div class="mb-3">
         <label for="id_bank_name" class="form-label">Bank</label>
-        <input list="bank-list" type="text" name="bank_name" id="id_bank_name" class="form-control" value="{{ bank_name }}" placeholder="Select or type new">
-        <datalist id="bank-list">
-          {% for b in banks %}
-          <option value="{{ b.name }}"></option>
-          {% endfor %}
-        </datalist>
+        <select name="bank_name" id="id_bank_name" class="form-select select2" data-placeholder="Select or type new">
+          {% if bank_name %}
+          <option value="{{ bank_name }}" selected>{{ bank_name }}</option>
+          {% endif %}
+        </select>
         {% if errors.bank_name %}<div class="text-danger">{{ errors.bank_name }}</div>{% endif %}
       </div>
       <div class="mb-3">
@@ -77,21 +76,20 @@
 {% endblock %}
 {% block extra_js %}
 <script>
-const bankInput = document.getElementById('id_bank_name');
-const bankList = document.getElementById('bank-list');
-if (bankInput) {
-  bankInput.addEventListener('input', () => {
-    fetch('{% url "bank_search" %}?q=' + encodeURIComponent(bankInput.value))
-      .then(r => r.json())
-      .then(data => {
-        bankList.innerHTML = '';
-        data.forEach(item => {
-          const opt = document.createElement('option');
-          opt.value = item.name;
-          bankList.appendChild(opt);
-        });
-      });
+$(function() {
+  $('#id_bank_name').select2({
+    tags: true,
+    width: '100%',
+    ajax: {
+      url: '{% url "bank_search" %}',
+      dataType: 'json',
+      delay: 250,
+      data: params => ({q: params.term}),
+      processResults: data => ({results: data.map(item => ({id: item.name, text: item.name}))}),
+      cache: true
+    },
+    placeholder: 'Select or type new'
   });
-}
+});
 </script>
 {% endblock %}

--- a/erp_project/templates/supplier_update_form.html
+++ b/erp_project/templates/supplier_update_form.html
@@ -49,12 +49,11 @@
       </div>
       <div class="mb-3">
         <label for="id_bank_name" class="form-label">Bank</label>
-        <input list="bank-list" type="text" name="bank_name" id="id_bank_name" class="form-control" value="{{ bank_name }}" placeholder="Select or type new">
-        <datalist id="bank-list">
-          {% for b in banks %}
-          <option value="{{ b.name }}"></option>
-          {% endfor %}
-        </datalist>
+        <select name="bank_name" id="id_bank_name" class="form-select select2" data-placeholder="Select or type new">
+          {% if bank_name %}
+          <option value="{{ bank_name }}" selected>{{ bank_name }}</option>
+          {% endif %}
+        </select>
         {% if errors.bank_name %}<div class="text-danger">{{ errors.bank_name }}</div>{% endif %}
       </div>
       <div class="mb-3">
@@ -77,21 +76,20 @@
 {% endblock %}
 {% block extra_js %}
 <script>
-const bankInput = document.getElementById('id_bank_name');
-const bankList = document.getElementById('bank-list');
-if (bankInput) {
-  bankInput.addEventListener('input', () => {
-    fetch('{% url "bank_search" %}?q=' + encodeURIComponent(bankInput.value))
-      .then(r => r.json())
-      .then(data => {
-        bankList.innerHTML = '';
-        data.forEach(item => {
-          const opt = document.createElement('option');
-          opt.value = item.name;
-          bankList.appendChild(opt);
-        });
-      });
+$(function() {
+  $('#id_bank_name').select2({
+    tags: true,
+    width: '100%',
+    ajax: {
+      url: '{% url "bank_search" %}',
+      dataType: 'json',
+      delay: 250,
+      data: params => ({q: params.term}),
+      processResults: data => ({results: data.map(item => ({id: item.name, text: item.name}))}),
+      cache: true
+    },
+    placeholder: 'Select or type new'
   });
-}
+});
 </script>
 {% endblock %}

--- a/workflow.md
+++ b/workflow.md
@@ -409,7 +409,7 @@ This workflow governs the full onboarding and financial lifecycle of high-value 
 * Input validation uses `phonenumbers` and `python-stdnum`.
 * Implemented OTP email verification on creation.
 * Suppliers can be toggled between connected and disconnected instead of deletion.
-* Supplier form suggests existing banks via datalist and enforces unique bank/SWIFT combinations and IBAN.
+* Supplier form uses a Select2 dropdown to search existing banks and allows typing a new name. It still enforces unique bank/SWIFT combinations and IBAN.
 * Supplier profile includes a description field and edit form.
 * Discontinue/reactivate suppliers with `can_discontinue_supplier` permission.
 * Updating phone or email triggers re-verification via OTP request.


### PR DESCRIPTION
## Summary
- use Select2 widget for bank field on supplier forms
- load jQuery and Select2 globally
- document new dropdown behaviour
- test that new Select2 markup is rendered

## Testing
- `python erp_project/manage.py test purchasing.tests.PurchasingLedgerTests purchasing.tests.IPhoneWorkflowIntegrationTests purchasing.tests`

------
https://chatgpt.com/codex/tasks/task_e_6859231065d08324b9530928f5211970