### PR TITLE
Fix warehouse list view with products

### DIFF
--- a/erp_project/inventory/tests.py
+++ b/erp_project/inventory/tests.py
@@ -45,6 +45,14 @@ class WarehouseViewTests(TestCase):
         self.assertContains(resp, 'value="EditW"')
         self.assertContains(resp, 'value="Loc"')
 
+    def test_warehouse_list_with_products(self):
+        """Warehouse list view should render even when products exist."""
+        Warehouse.objects.create(name='ListW', location='Loc', company=self.company)
+        unit = ProductUnit.objects.create(code='BX', name='Box')
+        Product.objects.create(name='Item', unit=unit, company=self.company)
+        resp = self.client.get(reverse('warehouse_list'))
+        self.assertEqual(resp.status_code, 200)
+
 
 class CategoryViewTests(TestCase):
     def setUp(self):

--- a/erp_project/inventory/views.py
+++ b/erp_project/inventory/views.py
@@ -40,12 +40,12 @@ class WarehouseListView(AdvancedListMixin, TemplateView):
         context = super().get_context_data(**kwargs)
         page = self.get_queryset()
         inv = {}
-        for prod in page:
-            qty_lot = StockLot.objects.filter(product=prod).aggregate(q=Sum('qty'))['q'] or 0
-            qty_in = StockMovement.objects.filter(product=prod, movement_type=StockMovement.IN).aggregate(q=Sum('quantity'))['q'] or 0
-            qty_out = StockMovement.objects.filter(product=prod, movement_type=StockMovement.OUT).aggregate(q=Sum('quantity'))['q'] or 0
-            qty_adj = InventoryAdjustment.objects.filter(product=prod).aggregate(q=Sum('qty'))['q'] or 0
-            inv[prod.id] = qty_lot + qty_in - qty_out + qty_adj
+        for wh in page:
+            qty_lot = StockLot.objects.filter(warehouse=wh).aggregate(q=Sum('qty'))['q'] or 0
+            qty_in = StockMovement.objects.filter(warehouse=wh, movement_type=StockMovement.IN).aggregate(q=Sum('quantity'))['q'] or 0
+            qty_out = StockMovement.objects.filter(warehouse=wh, movement_type=StockMovement.OUT).aggregate(q=Sum('quantity'))['q'] or 0
+            qty_adj = InventoryAdjustment.objects.filter(warehouse=wh).aggregate(q=Sum('qty'))['q'] or 0
+            inv[wh.id] = qty_lot + qty_in - qty_out + qty_adj
         context['page_obj'] = page
         context['inventory'] = inv
         context['search'] = True


### PR DESCRIPTION
## Summary
- fix inventory calculation in `WarehouseListView`
- ensure listing warehouses works when products exist
- add regression test for the list view

## Testing
- `python erp_project/manage.py test inventory`

------
https://chatgpt.com/codex/tasks/task_e_685a7b09fc8c83249fa450336a7a41ff